### PR TITLE
fix：canvas相关的销毁，防止内存泄漏

### DIFF
--- a/harmony/clipPath/src/main/cpp/ClipPathViewNoneNode.cpp
+++ b/harmony/clipPath/src/main/cpp/ClipPathViewNoneNode.cpp
@@ -66,7 +66,16 @@ ClipPathViewNoneNode::~ClipPathViewNoneNode() {
     NativeNodeApi::getInstance()->unregisterNodeCustomEvent(m_nodeHandle, ARKUI_NODE_CUSTOM_EVENT_ON_MEASURE);
     OH_Drawing_RectDestroy(mRectVb);
     OH_Drawing_RectDestroy(mRectVbDensity);
+    OH_Drawing_RectDestroy(mBounds);
+    OH_Drawing_RectDestroy(mRectPath);
+    OH_Drawing_PathDestroy(mPath);
+    OH_Drawing_PathDestroy(mPath2);
+    OH_Drawing_MatrixDestroy(mMatrix);
+    OH_Drawing_PenDestroy(mPaint);
+    OH_Drawing_PenDestroy(mPaintStroke);
+    OH_Drawing_CanvasDestroy(canvas);
     delete canvasCallback_;
+    delete mProps;
     canvasCallback_ = nullptr;
 }
 
@@ -92,6 +101,7 @@ void ClipPathViewNoneNode::setPanStyleMode(OH_Drawing_Canvas *canvas, int type) 
         break;
     }
     OH_Drawing_CanvasAttachBrush(canvas, cBrush);
+    OH_Drawing_BrushDestroy(cBrush);
 }
 
 void ClipPathViewNoneNode::OnDraw(ArkUI_NodeCustomEvent *event) {
@@ -110,6 +120,9 @@ void ClipPathViewNoneNode::OnDraw(ArkUI_NodeCustomEvent *event) {
     OH_Drawing_CanvasSaveLayer(canvas, OH_Drawing_RectCreate(0.0f, 0.0f, width_, height_), cBrush_);
 
     drawPath(canvas);
+    OH_Drawing_RectDestroy(canvasRect);
+    OH_Drawing_BrushDestroy(cBrush_back);
+    OH_Drawing_BrushDestroy(cBrush_);
 }
 
 void ClipPathViewNoneNode::drawPath(OH_Drawing_Canvas *canvas) {
@@ -300,12 +313,11 @@ void ClipPathViewNoneNode::setPaintStrokeProps() {
     OH_Drawing_PenSetJoin(mPaintStroke, mProps->getStrokeJoin());
     OH_Drawing_PenSetMiterLimit(mPaintStroke, mProps->getStrokeMiter());
     OH_Drawing_PathReset(mPath2);
+    mPath2 = OH_Drawing_PathCopy(mPath);
     if (mProps->getStrokeStart() != 0.0f || mProps->getStrokeEnd() != 1.0f) {
         OH_Drawing_PathMoveTo(mPath2, OH_Drawing_PathGetLength(mPath2, false) * mProps->getStrokeStart(),
                               OH_Drawing_PathGetLength(mPath2, false) * mProps->getStrokeEnd());
         OH_Drawing_PathLineTo(mPath2, 0.0f, 0.0f);
-    } else {
-        mPath2 = OH_Drawing_PathCopy(mPath);
     }
 }
 

--- a/harmony/clipPath/src/main/cpp/ClipPathViewNoneNode.h
+++ b/harmony/clipPath/src/main/cpp/ClipPathViewNoneNode.h
@@ -81,6 +81,7 @@ namespace rnoh {
         OH_Drawing_Path *mPath2{OH_Drawing_PathCreate()};
         OH_Drawing_Pen *mPaint{OH_Drawing_PenCreate()};
         OH_Drawing_Pen *mPaintStroke{OH_Drawing_PenCreate()};
+        OH_Drawing_Canvas *canvas{nullptr};
         float mTranslationX{0.0f};
         float mTranslationY{0.0f};
         bool mTranslationIsPercent{false};


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- fix：canvas相关的销毁，防止内存泄漏

Close: #16 

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
