### PR TITLE
fix: fixed zooming animation center point dead

### DIFF
--- a/harmony/clipPath/src/main/cpp/ClipPathProps.h
+++ b/harmony/clipPath/src/main/cpp/ClipPathProps.h
@@ -68,10 +68,10 @@ public:
                                                         : OH_Drawing_PenLineCapStyle::LINE_FLAT_CAP);
     }
     OH_Drawing_PenLineJoinStyle getStrokeJoin() {
-        return mStrokeCap.compare("round") == 0
+        return mStrokeJoin.compare("round") == 0
                    ? OH_Drawing_PenLineJoinStyle::LINE_ROUND_JOIN
-                   : (mStrokeCap.compare("bevel") == 0 ? OH_Drawing_PenLineJoinStyle::LINE_BEVEL_JOIN
-                                                       : OH_Drawing_PenLineJoinStyle::LINE_MITER_JOIN);
+                   : (mStrokeJoin.compare("bevel") == 0 ? OH_Drawing_PenLineJoinStyle::LINE_BEVEL_JOIN
+                                                        : OH_Drawing_PenLineJoinStyle::LINE_MITER_JOIN);
     }
 
     float getStrokeMiter() { return mStrokeMiter; }

--- a/harmony/clipPath/src/main/cpp/ClipPathViewNoneNode.cpp
+++ b/harmony/clipPath/src/main/cpp/ClipPathViewNoneNode.cpp
@@ -77,6 +77,7 @@ ClipPathViewNoneNode::~ClipPathViewNoneNode() {
     delete canvasCallback_;
     delete mProps;
     canvasCallback_ = nullptr;
+    mProps = nullptr;
 }
 
 void ClipPathViewNoneNode::insertChild(ArkUINode &child, std::size_t index) {
@@ -106,18 +107,19 @@ void ClipPathViewNoneNode::setPanStyleMode(OH_Drawing_Canvas *canvas, int type) 
 
 void ClipPathViewNoneNode::OnDraw(ArkUI_NodeCustomEvent *event) {
     auto *drawContext = OH_ArkUI_NodeCustomEvent_GetDrawContextInDraw(event);
-    auto *canvas = reinterpret_cast<OH_Drawing_Canvas *>(OH_ArkUI_DrawContext_GetCanvas(drawContext));
+    canvas = reinterpret_cast<OH_Drawing_Canvas *>(OH_ArkUI_DrawContext_GetCanvas(drawContext));
     auto width_ = OH_Drawing_CanvasGetWidth(canvas);
     auto height_ = OH_Drawing_CanvasGetHeight(canvas);
 
-    OH_Drawing_CanvasSaveLayer(canvas, OH_Drawing_RectCreate(0.0f, 0.0f, width_, height_), nullptr);
-    OH_Drawing_Brush *cBrush_1 = OH_Drawing_BrushCreate();
-    OH_Drawing_BrushSetColor(cBrush_1, OH_Drawing_ColorSetArgb(0xff, 0xff, 0xff, 0xff));
-    OH_Drawing_CanvasDrawBackground(canvas, cBrush_1);
+    auto canvasRect = OH_Drawing_RectCreate(0.0f, 0.0f, width_, height_);
+    OH_Drawing_CanvasSaveLayer(canvas, canvasRect, nullptr);
+    OH_Drawing_Brush *cBrush_back = OH_Drawing_BrushCreate();
+    OH_Drawing_BrushSetColor(cBrush_back, OH_Drawing_ColorSetArgb(0xff, 0xff, 0xff, 0xff));
+    OH_Drawing_CanvasDrawBackground(canvas, cBrush_back);
 
     OH_Drawing_Brush *cBrush_ = OH_Drawing_BrushCreate();
     OH_Drawing_BrushSetBlendMode(cBrush_, BLEND_MODE_DST_OUT);
-    OH_Drawing_CanvasSaveLayer(canvas, OH_Drawing_RectCreate(0.0f, 0.0f, width_, height_), cBrush_);
+    OH_Drawing_CanvasSaveLayer(canvas, canvasRect, cBrush_);
 
     drawPath(canvas);
     OH_Drawing_RectDestroy(canvasRect);
@@ -338,7 +340,7 @@ void ClipPathViewNoneNode::canvasTransform() {
             rotX = toDip(mRotationOx);
             rotY = toDip(mRotationOy);
         }
-        OH_Drawing_MatrixPostRotate(mMatrix, mRotation, 100, 100);
+        OH_Drawing_MatrixPostRotate(mMatrix, mRotation, rotX, rotY);
     }
 
     if (mScaleX != 1.0f || mScaleY != 1.0f) {


### PR DESCRIPTION
# Summary

- fix: fixed zooming animation center point dead
- Close: #18 

## Test Plan

设置ClipPathView缩放动画及其中心点，观察缩放动画的位置

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
